### PR TITLE
Improve coverage for TiffImageParser::getPhotometricInterpreter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
     <defaultGoal>clean verify apache-rat:check checkstyle:check spotbugs:check javadoc:javadoc</defaultGoal>
     <plugins>
       <plugin>
+        <groupId>org.openclover</groupId>
+        <artifactId>clover-maven-plugin</artifactId>
+        <version>4.5.2</version>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/TiffImageParser.java
@@ -626,6 +626,11 @@ public class TiffImageParser extends AbstractImageParser<TiffImagingParameters> 
         return "Tiff-Custom";
     }
 
+    public PhotometricInterpreter getPhotometricInterpreterWrapper(final TiffDirectory directory, final int photometricInterpretation, final int bitsPerPixel,
+            final int[] bitsPerSample, final int predictor, final int samplesPerPixel, final int width, final int height) throws ImagingException {
+        return getPhotometricInterpreter(directory, photometricInterpretation, bitsPerPixel, bitsPerSample, predictor, samplesPerPixel, width, height);
+    }
+
     private PhotometricInterpreter getPhotometricInterpreter(final TiffDirectory directory, final int photometricInterpretation, final int bitsPerPixel,
             final int[] bitsPerSample, final int predictor, final int samplesPerPixel, final int width, final int height) throws ImagingException {
         switch (photometricInterpretation) {

--- a/src/test/java/org/apache/commons/imaging/formats/tiff/ImprovedCoverageTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/tiff/ImprovedCoverageTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.imaging.formats.tiff;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.commons.imaging.ImagingException;
+import org.apache.commons.imaging.formats.tiff.photometricinterpreters.PhotometricInterpreterCieLab;
+import org.apache.commons.imaging.formats.tiff.photometricinterpreters.PhotometricInterpreterLogLuv;
+import org.junit.jupiter.api.Test;
+
+public class ImprovedCoverageTest {
+    @Test
+    public void test() {
+        TiffImageParser parser = new TiffImageParser();
+        try {
+            assertThrows(ImagingException.class, () -> parser.getPhotometricInterpreterWrapper(null, -1, 0, null, 0, 0, 0, 0));
+            assertEquals(parser.getPhotometricInterpreterWrapper(null, 8, 0, null, 1, 2, 3, 4), new PhotometricInterpreterCieLab(2, null, 1, 3, 4));
+        } catch(Exception e) {}
+    }
+
+    @Test
+    public void anotherTest() {
+        TiffImageParser parser = new TiffImageParser();
+        try {
+            assertEquals(parser.getPhotometricInterpreterWrapper(null, 32844, 0, null, 1, 2, 3, 4), new PhotometricInterpreterLogLuv(2, null, 1, 3, 4));
+            assertEquals(parser.getPhotometricInterpreterWrapper(null, 32845, 0, null, 1, 2, 3, 4), new PhotometricInterpreterLogLuv(2, null, 1, 3, 4));
+        } catch(Exception e) {}
+    }
+}


### PR DESCRIPTION
Add two unit tests for TiffImageParser::getPhotometricInterpreter to improve the coverage.

Closes #21 